### PR TITLE
allow CLI to work on global install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "transform a stream into a quoted string",
   "main": "index.js",
+  "bin": {
+    "quote-stream": "bin/cmd.js"
+  },
   "dependencies": {
     "through2": "~0.4.1",
     "minimist": "0.0.8"


### PR DESCRIPTION
to allow users to install with `-g` and then run `quote-stream` from shell