### PR TITLE
Remove minimist dependency

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
 var quote = require('../');
-var minimist = require('minimist');
 var fs = require('fs');
 
-var argv = minimist(process.argv.slice(2), { alias: { h: 'help' } });
-if (argv.help) {
+var argv = process.argv.slice(2);
+if (argv.indexOf("--help") > -1 || argv.indexOf("--h") > -1) {
     var s = fs.createReadStream(__dirname + '/usage.txt');
     return s.pipe(process.stdout);
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "buffer-equal": "0.0.1",
-    "minimist": "^1.1.3",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There are more than 80k packages using quote-stream, and all have a `Prototype Pollution` security issue due to minimist `v1.1.3`. When users install packages that depends, even not directly, on quote-stream, a vulnerability error is found by NPM. For example:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.2.1 <1.0.0 || >=1.2.3                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ mapillary_sprite_source [dev]                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ mapillary_sprite_source > brfs > static-module >             │
│               │ quote-stream > minimist                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1179                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

This package don`t need minimist at all, only is used to parse a `--help` and `--h` option in a script, so I've removed parsing this with `argv.indexOf`.